### PR TITLE
Support absolute paths

### DIFF
--- a/src/Gfontsdownloader.php
+++ b/src/Gfontsdownloader.php
@@ -31,7 +31,7 @@ class GFontsDownloader {
                 throw new \Exception("Invalid Google Fonts URL");
             }
             $this->url = $url;
-            $this->dir = trim($dir, "/");
+            $this->dir = rtrim($dir, "/");
         } catch (\Exception $e) {
             echo ($e->getMessage());
         }


### PR DESCRIPTION
At present absolute paths are converted to relative paths by trimming '/' from front of paths. Might be better to also support absolute paths by using rtrim() rather than trim();